### PR TITLE
feat: Add datasource for LDAP user

### DIFF
--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -1,0 +1,24 @@
+# ldap_user Data Source
+
+`ldap_user` is a data source for retrieving an LDAP user.
+
+## Example Usage
+
+```hcl
+data "ldap_user" "user" {
+  ou          = "OU=MyOU,DC=domain,DC=tld"
+  name        = "MyUser"
+}
+```
+
+## Argument Reference
+
+* `ou` - (Required) OU where LDAP user will be search.
+* `name` - (Optional) The name of the LDAP user.
+* `sam_account_name` - (Optional) The sAMAccountName of the LDAP user.
+* `user_principal_name` - (Optional) The userPrincipalName of the LDAP user.
+
+## Attribute Reference
+
+* `id` - LDAP user DN.
+* `description` - Description attribute for the LDAP user.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Ouest-France/terraform-provider-ldap
 go 1.13
 
 require (
-	github.com/Ouest-France/goldap v0.3.0
-	github.com/go-ldap/ldap/v3 v3.2.3
+	github.com/Ouest-France/goldap v0.4.0
+	github.com/go-ldap/ldap/v3 v3.2.4
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.3
 )

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c h1:/IBSNwUN8+eKzU
 github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Ouest-France/goldap v0.3.0 h1:ZD6g+VaIM6WhGI6S980M2eSGUHRZMSct3ytVxFaDKvk=
-github.com/Ouest-France/goldap v0.3.0/go.mod h1:S6YFjrPJ4HUeDJdIky3z6j1uKXHDwGOMFAMCMb4xMC4=
+github.com/Ouest-France/goldap v0.4.0 h1:wkD1q5V2COkucE2HnQWqcgTHJH6J/A9WgwLZrnM4qWE=
+github.com/Ouest-France/goldap v0.4.0/go.mod h1:RwWUzDNiNoS0UXEdAjcoIayOR5TTbHyqBbAmM5dcNJo=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
@@ -85,8 +85,8 @@ github.com/go-git/go-git/v5 v5.1.0/go.mod h1:ZKfuPUoY1ZqIG4QG9BDBh3G4gLM5zvPuSJA
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-ldap/ldap/v3 v3.2.3 h1:FBt+5w3q/vPVPb4eYMQSn+pOiz4zewPamYhlGMmc7yM=
-github.com/go-ldap/ldap/v3 v3.2.3/go.mod h1:iYS1MdmrmceOJ1QOTnRXrIs7i3kloqtmGQjRvjKpyMg=
+github.com/go-ldap/ldap/v3 v3.2.4 h1:PFavAq2xTgzo/loE8qNXcQaofAaqIpI4WgaLdv+1l3E=
+github.com/go-ldap/ldap/v3 v3.2.4/go.mod h1:iYS1MdmrmceOJ1QOTnRXrIs7i3kloqtmGQjRvjKpyMg=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/ldap/data_source_resource_ldap_user.go
+++ b/ldap/data_source_resource_ldap_user.go
@@ -1,0 +1,94 @@
+package ldap
+
+import (
+	"context"
+
+	"github.com/Ouest-France/goldap"
+	"github.com/go-ldap/ldap/v3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceLDAPUser() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceLDAPUserRead,
+		Schema: map[string]*schema.Schema{
+			"ou": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"name", "sam_account_name", "user_principal_name"},
+			},
+			"sam_account_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"user_principal_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceLDAPUserRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return resourceLDAPUserRead(context.WithValue(ctx, CallerTypeKey, DatasourceCaller), d, m)
+}
+
+func resourceLDAPUserRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*goldap.Client)
+
+	user, err := client.ReadUser(d.Get("ou").(string), d.Get("name").(string), d.Get("sam_account_name").(string), d.Get("user_principal_name").(string))
+
+	if err != nil {
+		if err.(*ldap.Error).ResultCode == ldap.LDAPResultNoSuchObject {
+			// Object doesn't exist
+
+			// If Read is called from a datasource, return an error
+			if ctx.Value(CallerTypeKey) == DatasourceCaller {
+				return diag.FromErr(err)
+			}
+
+			// If not a call from datasource, remove the resource from the state
+			// and cleanly return
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	d.SetId(user["distinguishedName"][0])
+
+	if val, ok := user["name"]; ok {
+		if err := d.Set("name", val[0]); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if val, ok := user["sAMAccountName"]; ok {
+		if err := d.Set("sam_account_name", val[0]); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if val, ok := user["userPrincipalName"]; ok {
+		if err := d.Set("user_principal_name", val[0]); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if val, ok := user["description"]; ok {
+		if err := d.Set("description", val[0]); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return diag.FromErr(err)
+}

--- a/ldap/provider.go
+++ b/ldap/provider.go
@@ -51,6 +51,7 @@ func Provider() *schema.Provider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"ldap_group": dataSourceLDAPGroup(),
+			"ldap_user":  dataSourceLDAPUser(),
 		},
 		ConfigureFunc: providerConfigure,
 	}


### PR DESCRIPTION
Resolves https://github.com/Ouest-France/terraform-provider-ldap/issues/11

Requires https://github.com/Ouest-France/goldap/pull/5

I was wondering, how to make `name`, `user_principal_name`, `sam_account_name` optionals and only one of them is required ? @pablo-ruth  any suggestions ?