### PR TITLE
add argument filter for generic selection of user, add attribute data…

### DIFF
--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -17,8 +17,10 @@ data "ldap_user" "user" {
 * `name` - (Required) Name of the LDAP user.
 * `sam_account_name` - (Optional) sAMAccountName of the LDAP user.
 * `user_principal_name` - (Optional) UPN of the LDAP user.
+* `filter` - (Optional) LDAP-Filter for generic selection of the user
 
 ## Attribute Reference
 
 * `id` - The DN of the LDAP user.
 * `description` - Description attribute for the LDAP user.
+* `data_json` - The attributes as JSON-encoded string.

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/Ouest-France/terraform-provider-ldap
 
 go 1.18
 
+// temporary replacement waiting for https://github.com/Ouest-France/goldap/pull/21
+replace github.com/Ouest-France/goldap => /Users/lars/github/l-with/goldap
+
 require (
 	github.com/Ouest-France/goldap v0.6.1
 	github.com/go-ldap/ldap/v3 v3.4.4


### PR DESCRIPTION
…_json to retrieve complete LDAP attributes

With filter the provider can also be used for LDAP directories without standard identifying attributes.
For instance Kolab uses `uid` as identifier, alternatively `mail` can be used.
Also the is no attribute `distinguishedName. Thus a dn with filter and ou is used as identifier if the argument filter is provided.

The goldap packaged is temporary replaced, since the pull request on this package is needed for this pull request.