### PR TITLE
Enable debug mode on LDAP connection if `TF_LOG` is set to `DEBUG` or higher

### DIFF
--- a/ldap/provider.go
+++ b/ldap/provider.go
@@ -2,6 +2,7 @@ package ldap
 
 import (
 	"github.com/Ouest-France/goldap"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -62,7 +63,6 @@ func Provider() *schema.Provider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-
 	client := &goldap.Client{
 		Host:         d.Get("host").(string),
 		Port:         d.Get("port").(int),
@@ -76,6 +76,10 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	err := client.Connect()
 	if err != nil {
 		return nil, err
+	}
+
+	if logging.IsDebugOrHigher() {
+		client.Conn.Debug.Enable(true)
 	}
 
 	return client, nil


### PR DESCRIPTION
Hi,

this PR enables debug mode on the underlying LDAP connection if `TF_LOG` is set to `DEBUG` or higher.

This can be useful to understand errors, e.g.:

```
# TF_LOG=trace terraform plan
...
2022-12-16T11:34:34.605+0100 [DEBUG] provider.terraform-provider-ldap: LDAP Request: (Universal, Constructed, Sequence and Sequence of) Len=135 "<nil>"
2022-12-16T11:34:34.605+0100 [DEBUG] provider.terraform-provider-ldap:  MessageID: (Universal, Primitive, Integer) Len=1 "4"
2022-12-16T11:34:34.605+0100 [DEBUG] provider.terraform-provider-ldap:  Search Request: (Application, Constructed, 0x03) Len=129 "<nil>"
2022-12-16T11:34:34.605+0100 [DEBUG] provider.terraform-provider-ldap:   Base DN: (Universal, Primitive, Octet String) Len=47 "CN=my_group,OU=my_incomplete_ou"
2022-12-16T11:34:34.605+0100 [DEBUG] provider.terraform-provider-ldap:   Scope: (Universal, Primitive, Enumerated) Len=1 "0"
2022-12-16T11:34:34.605+0100 [DEBUG] provider.terraform-provider-ldap:   Deref Aliases: (Universal, Primitive, Enumerated) Len=1 "0"
2022-12-16T11:34:34.605+0100 [DEBUG] provider.terraform-provider-ldap:   Size Limit: (Universal, Primitive, Integer) Len=1 "0"
2022-12-16T11:34:34.605+0100 [DEBUG] provider.terraform-provider-ldap:   Time Limit: (Universal, Primitive, Integer) Len=1 "0"
2022-12-16T11:34:34.605+0100 [DEBUG] provider.terraform-provider-ldap:   Types Only: (Universal, Primitive, Boolean) Len=1 "false"
2022-12-16T11:34:34.605+0100 [DEBUG] provider.terraform-provider-ldap:   Equality Match: (Context, Constructed, 0x03) Len=20 "<nil>"
2022-12-16T11:34:34.605+0100 [DEBUG] provider.terraform-provider-ldap:    Attribute: (Universal, Primitive, Octet String) Len=11 "objectclass"
2022-12-16T11:34:34.605+0100 [DEBUG] provider.terraform-provider-ldap:    Condition: (Universal, Primitive, Octet String) Len=5 "group"
2022-12-16T11:34:34.605+0100 [DEBUG] provider.terraform-provider-ldap:   Attributes: (Universal, Constructed, Sequence and Sequence of) Len=41 "<nil>"
2022-12-16T11:34:34.605+0100 [DEBUG] provider.terraform-provider-ldap:    Attribute: (Universal, Primitive, Octet String) Len=4 "name"
2022-12-16T11:34:34.605+0100 [DEBUG] provider.terraform-provider-ldap:    Attribute: (Universal, Primitive, Octet String) Len=11 "description"
2022-12-16T11:34:34.605+0100 [DEBUG] provider.terraform-provider-ldap:    Attribute: (Universal, Primitive, Octet String) Len=9 "groupType"
2022-12-16T11:34:34.605+0100 [DEBUG] provider.terraform-provider-ldap:    Attribute: (Universal, Primitive, Octet String) Len=9 "managedBy"
2022-12-16T11:34:34.605+0100 [DEBUG] provider.terraform-provider-ldap: 2022/12/16 11:34:34 flags&startTLS = 0
2022-12-16T11:34:34.605+0100 [DEBUG] provider.terraform-provider-ldap: 2022/12/16 11:34:34 4: returning
2022-12-16T11:34:34.605+0100 [DEBUG] provider.terraform-provider-ldap: 2022/12/16 11:34:34 4: waiting for response
2022-12-16T11:34:34.605+0100 [DEBUG] provider.terraform-provider-ldap: 2022/12/16 11:34:34 Sending message 4

...
2022-12-16T11:34:34.636+0100 [DEBUG] provider.terraform-provider-ldap: 2022/12/16 11:34:34 Receiving message 4
2022-12-16T11:34:34.636+0100 [DEBUG] provider.terraform-provider-ldap: 2022/12/16 11:34:34 4: got response 0xc0001b20e0
2022-12-16T11:34:34.636+0100 [DEBUG] provider.terraform-provider-ldap: LDAP Response: (Universal, Constructed, Sequence and Sequence of) Len=79 "<nil>"
2022-12-16T11:34:34.636+0100 [DEBUG] provider.terraform-provider-ldap:  Message ID: (Universal, Primitive, Integer) Len=1 "4"
2022-12-16T11:34:34.636+0100 [DEBUG] provider.terraform-provider-ldap:  Search Result Done: (Application, Constructed, 0x05) Len=74 "<nil>"
2022-12-16T11:34:34.636+0100 [DEBUG] provider.terraform-provider-ldap:   Result Code (Operations Error): (Universal, Primitive, Enumerated) Len=1 "1"
2022-12-16T11:34:34.636+0100 [DEBUG] provider.terraform-provider-ldap:   Matched DN (): (Universal, Primitive, Octet String) Len=0 ""
2022-12-16T11:34:34.636+0100 [DEBUG] provider.terraform-provider-ldap:   Error Message: (Universal, Primitive, Octet String) Len=67 "000020D6: SvcErr: DSID-03100836, problem 5012 (DIR_ERROR), data 0\n\x00"
2022-12-16T11:34:34.636+0100 [DEBUG] provider.terraform-provider-ldap: 2022/12/16 11:34:34 Finished message 4
```