### PR TITLE
feat: Forcenew when group_type changes

### DIFF
--- a/ldap/resource_ldap_group.go
+++ b/ldap/resource_ldap_group.go
@@ -67,6 +67,7 @@ func resourceLDAPGroup() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
+				ForceNew:    true,
 			},
 			"managed_by": {
 				Description: "ManagedBy attribute",


### PR DESCRIPTION
Hi,

Thank you for your amazing module ! 

We recently encountered a problem where a misconfiguration led us to create "Global" Groupes, instead of "Domain Local".
When we corrected the mistake, the module seek a simple value change for the "group_type" attribute, which does not work as Active Directory refuses to convert "Global" to "Domain Local" and vice versa.

I'm proposing this modification, so that the modification of the groupe_type triggers a destroy / create.

I've never touched any module code, so hopefully this is right, thank you in advance for any advice.

Kind regards,